### PR TITLE
Add Flatten Forms and Remove Metadata PDF tools

### DIFF
--- a/src/lib/pdf-handlers/flattenForm.js
+++ b/src/lib/pdf-handlers/flattenForm.js
@@ -1,0 +1,40 @@
+import {
+  createPDF,
+  pdfArrayToBlob,
+  flattenPDFForm,
+  zipToBlob,
+  rotatePDF,
+} from "pdf-actions";
+import { saveAs } from "file-saver";
+import JSZip from "jszip";
+
+const flattenFormHandler = async (files, asZip = true) => {
+  let zip;
+  if (asZip) {
+    zip = new JSZip();
+  }
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (file.deleted) {
+      continue;
+    }
+    const pdfFile = await createPDF.PDFDocumentFromFile(file);
+    let flattenFormPDF = await flattenPDFForm(pdfFile);
+    if (file.rotate) {
+      flattenFormPDF = await rotatePDF(flattenFormPDF, file.rotate);
+    }
+    const fileArray = await flattenFormPDF.save();
+    if (asZip) {
+      zip.file(`flatten-${file.name}`, fileArray);
+    } else {
+      const pdfBlob = pdfArrayToBlob(fileArray);
+      saveAs(pdfBlob, `flatten-${file.name}`);
+    }
+  }
+  if (asZip) {
+    const zipBlob = await zipToBlob(zip);
+    saveAs(zipBlob, "flattenedPDFFiles.zip");
+  }
+};
+
+export default flattenFormHandler;

--- a/src/lib/pdf-handlers/removeMetaData.js
+++ b/src/lib/pdf-handlers/removeMetaData.js
@@ -1,0 +1,13 @@
+import { saveAs } from "file-saver";
+import { createPDF, removeMetaData, pdfArrayToBlob } from "pdf-actions";
+
+const removeMetaDataHandler = async (files) => {
+  const file = files[0];
+  const pdfDocument = await createPDF.PDFDocumentFromFile(file);
+  const newPDF = await removeMetaData(pdfDocument);
+  const pdfFile = await newPDF.save();
+  const pdfBlob = pdfArrayToBlob(pdfFile);
+  saveAs(pdfBlob, file.name);
+};
+
+export default removeMetaDataHandler;

--- a/src/lib/pdftoolsconfig.js
+++ b/src/lib/pdftoolsconfig.js
@@ -10,6 +10,8 @@ import { useDictionary } from "@/lib/DictionaryProviderClient";
 import mergePDFHandler from "./pdf-handlers/mergePDF.js";
 import splitPDFHandler from "./pdf-handlers/splitPDF.js";
 import rotatePDFHandler from "./pdf-handlers/rotatePDF.js";
+import flattenFormHandler from "./pdf-handlers/flattenForm.js";
+import removeMetaDataHandler from "./pdf-handlers/removeMetaData.js";
 
 let imageURLFunction, getPDFPageCount;
 const acceptPDFFilesProps = {
@@ -123,6 +125,41 @@ const pdftoolsconfig = {
         </div>
       );
     },
+  },
+  flatten_forms: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFiles,
+    multiple: true,
+    reorder: false,
+    processor: (files) => flattenFormHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: ({ file }) => (
+      <div className="mx-auto max-w-[80%] flex-col">
+        <FileRotate file={file} />
+        <FileDelete file={file} />
+      </div>
+    ),
+    LeftExtra: ({ files }) => {
+      const { pdf_tools } = useDictionary();
+      return (
+        <div className="flex flex-col gap-4">
+          <GlassButton onClick={() => flattenFormHandler(files, false)}>
+            {pdf_tools.main.save_as_individual}
+          </GlassButton>
+          <LeftRotate files={files} />
+        </div>
+      );
+    },
+  },
+  remove_metadata: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFiles,
+    multiple: false,
+    reorder: false,
+    processor: (files) => removeMetaDataHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: null,
+    LeftExtra: null,
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `flattenForm.js` handler: flattens PDF form fields with optional rotation and zip/individual download support
- Add `removeMetaData.js` handler: strips metadata from a single PDF file
- Register both tools in `pdftoolsconfig.js` with appropriate UI config (preview, file extras, left panel extras)

## Test plan
- [x] `pnpm build` succeeds -- validates imports, SSG generation, and route creation
- [x] Static routes `/en/pdf-tools/flatten_forms` and `/en/pdf-tools/remove_metadata` generated correctly
- [ ] Manual test: upload PDFs to flatten_forms tool, verify form fields are flattened in output
- [ ] Manual test: upload a PDF to remove_metadata tool, verify metadata is stripped from output

🤖 Generated with [Claude Code](https://claude.com/claude-code)