### PR TITLE
Add Page Numbers and Edit Metadata tools

### DIFF
--- a/src/components/LeftEditMetaData.jsx
+++ b/src/components/LeftEditMetaData.jsx
@@ -1,0 +1,66 @@
+"use client";
+import React, { useEffect } from "react";
+
+const inputFields = [
+  { title: "Title", inputId: "title", inputType: "text" },
+  { title: "Subject", inputId: "subject", inputType: "text" },
+  { title: "Author", inputId: "author", inputType: "text" },
+  { title: "Creator", inputId: "creator", inputType: "text" },
+  { title: "Producer", inputId: "producer", inputType: "text" },
+  { title: "Keywords(,)", inputId: "keywords", inputType: "text" },
+  {
+    title: "Creation Date",
+    inputId: "documentCreationDate",
+    inputType: "datetime-local",
+  },
+  {
+    title: "Modification Date",
+    inputId: "documentModificationDate",
+    inputType: "datetime-local",
+  },
+];
+
+export default function LeftEditMetaData({ file }) {
+  useEffect(() => {
+    file.metaDataOptions = {
+      title: "",
+      subject: "",
+      author: "",
+      creator: "",
+      producer: "",
+      keywords: [],
+      documentCreationDate: new Date(),
+      documentModificationDate: new Date(),
+    };
+  }, []);
+
+  const handleTextInputChange = (newValue, valueType) => {
+    if (!file.metaDataOptions) file.metaDataOptions = {};
+    file.metaDataOptions[valueType] = newValue;
+    if (valueType === "keywords") {
+      file.metaDataOptions[valueType] = newValue.split(",");
+    }
+  };
+
+  return (
+    <div className="mt-2 w-full border-y-2 border-[#E9B4BF80] py-2 tracking-wider">
+      Meta Data Options - All Details Mandatory
+      {inputFields.map((inputField) => (
+        <div
+          key={inputField.inputId}
+          className="mt-2 flex items-center justify-between"
+        >
+          {inputField.title}
+          <input
+            className="h-8 rounded-md bg-[#E9B4BF80] pl-2"
+            id={inputField.inputId}
+            type={inputField.inputType}
+            onChange={(e) =>
+              handleTextInputChange(e.target.value, inputField.inputId)
+            }
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/LeftPageNumbers.jsx
+++ b/src/components/LeftPageNumbers.jsx
@@ -1,0 +1,144 @@
+"use client";
+import React, { useEffect } from "react";
+
+export default function LeftPageNumbers({ file }) {
+  useEffect(() => {
+    file.firstPageNumber = 1;
+    file.startingPage = 1;
+    file.endingPage = file.pageCount;
+    file.margin = "Recommended";
+    file.pageNumberPosition = "b-c";
+    file.pageNumberFontSize = 12;
+  }, []);
+
+  const clampAndSet = (e, prop, min, max) => {
+    let num = parseInt(e.target.value);
+    if (num < min) {
+      num = min;
+      e.target.value = min;
+    }
+    if (max !== undefined && num > max) {
+      num = max;
+      e.target.value = max;
+    }
+    file[prop] = num;
+  };
+
+  return (
+    <div className="w-full border-y-2 border-[#E9B4BF80] py-2 tracking-wider">
+      Page Number Options
+      <div className="mt-2 flex items-center justify-between">
+        Position
+        <div className="grid grid-cols-3 border-2 border-[#E9B4BF80]">
+          <div className="flex h-[30px] w-[30px] items-center justify-center border-b-2 border-r-2 border-dotted border-[#E9B4BF80]">
+            <input
+              type="radio"
+              name="position"
+              value="t-l"
+              onChange={(e) => { file.pageNumberPosition = e.target.value; }}
+            />
+          </div>
+          <div className="flex h-[30px] w-[30px] items-center justify-center border-b-2 border-r-2 border-dotted border-[#E9B4BF80]">
+            <input
+              type="radio"
+              name="position"
+              value="t-c"
+              onChange={(e) => { file.pageNumberPosition = e.target.value; }}
+            />
+          </div>
+          <div className="flex h-[30px] w-[30px] items-center justify-center border-b-2 border-dotted border-[#E9B4BF80]">
+            <input
+              type="radio"
+              name="position"
+              value="t-r"
+              onChange={(e) => { file.pageNumberPosition = e.target.value; }}
+            />
+          </div>
+          <div className="h-[30px] w-[30px] border-b-2 border-r-2 border-dotted border-[#E9B4BF80]"></div>
+          <div className="h-[30px] w-[30px] border-b-2 border-r-2 border-dotted border-[#E9B4BF80]"></div>
+          <div className="h-[30px] w-[30px] border-b-2 border-dotted border-[#E9B4BF80]"></div>
+          <div className="flex h-[30px] w-[30px] items-center justify-center border-r-2 border-dotted border-[#E9B4BF80]">
+            <input
+              type="radio"
+              name="position"
+              value="b-l"
+              onChange={(e) => { file.pageNumberPosition = e.target.value; }}
+            />
+          </div>
+          <div className="flex h-[30px] w-[30px] items-center justify-center border-r-2 border-dotted border-[#E9B4BF80]">
+            <input
+              type="radio"
+              name="position"
+              defaultChecked={true}
+              value="b-c"
+              onChange={(e) => { file.pageNumberPosition = e.target.value; }}
+            />
+          </div>
+          <div className="flex h-[30px] w-[30px] items-center justify-center">
+            <input
+              type="radio"
+              name="position"
+              value="b-r"
+              onChange={(e) => { file.pageNumberPosition = e.target.value; }}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        Margin
+        <select
+          id="margin"
+          className="w-1/2 rounded-md bg-[#E9B4BF80] py-2 pl-2 text-white"
+          defaultValue="Recommended"
+          onChange={(e) => { file.margin = e.target.value; }}
+        >
+          <option value="Small">Small</option>
+          <option value="Recommended">Recommended</option>
+          <option value="Big">Big</option>
+        </select>
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        Starting Page
+        <input
+          className="w-[50px] rounded-md bg-[#E9B4BF80] text-center caret-transparent"
+          type="number"
+          defaultValue="1"
+          min="1"
+          max={file.pageCount}
+          onChange={(e) => clampAndSet(e, "startingPage", 1, file.pageCount)}
+        />
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        Ending Page
+        <input
+          className="w-[50px] rounded-md bg-[#E9B4BF80] text-center caret-transparent"
+          type="number"
+          defaultValue={file.pageCount}
+          min="1"
+          max={file.pageCount}
+          onChange={(e) => clampAndSet(e, "endingPage", 1, file.pageCount)}
+        />
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        First Number
+        <input
+          className="w-[50px] rounded-md bg-[#E9B4BF80] text-center caret-transparent"
+          type="number"
+          defaultValue="1"
+          min="1"
+          onChange={(e) => clampAndSet(e, "firstPageNumber", 1)}
+        />
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        Font Size
+        <input
+          className="w-[50px] rounded-md bg-[#E9B4BF80] text-center caret-transparent"
+          type="number"
+          defaultValue="12"
+          min="1"
+          onChange={(e) => clampAndSet(e, "pageNumberFontSize", 1)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/pdf-handlers/addPageNumbers.js
+++ b/src/lib/pdf-handlers/addPageNumbers.js
@@ -1,0 +1,21 @@
+import { saveAs } from "file-saver";
+import { addPageNumbers, createPDF, pdfArrayToBlob } from "pdf-actions";
+
+const addPageNumbersHandler = async (files) => {
+  const file = files[0];
+  const pdfDoc = await createPDF.PDFDocumentFromFile(file);
+  const pdfFile = await addPageNumbers(
+    pdfDoc,
+    file.pageNumberPosition,
+    file.margin,
+    file.startingPage,
+    file.endingPage,
+    file.firstPageNumber,
+    file.pageNumberFontSize,
+  );
+  const pdfArray = await pdfFile.save();
+  const pdfBlob = pdfArrayToBlob(pdfArray);
+  saveAs(pdfBlob, `pageNumber-${file.name}`);
+};
+
+export default addPageNumbersHandler;

--- a/src/lib/pdf-handlers/editMetaData.js
+++ b/src/lib/pdf-handlers/editMetaData.js
@@ -1,0 +1,18 @@
+import { saveAs } from "file-saver";
+import { createPDF, editMetaData, pdfArrayToBlob } from "pdf-actions";
+
+const editMetaDataHandler = async (files) => {
+  const file = files[0];
+  const options = { ...file.metaDataOptions };
+  options["documentCreationDate"] = new Date(options["documentCreationDate"]);
+  options["documentModificationDate"] = new Date(
+    options["documentModificationDate"],
+  );
+  const pdfDocument = await createPDF.PDFDocumentFromFile(file);
+  const newPDF = await editMetaData(pdfDocument, options);
+  const pdfFile = await newPDF.save();
+  const pdfBlob = pdfArrayToBlob(pdfFile);
+  saveAs(pdfBlob, file.name);
+};
+
+export default editMetaDataHandler;

--- a/src/lib/pdftoolsconfig.js
+++ b/src/lib/pdftoolsconfig.js
@@ -10,6 +10,10 @@ import { useDictionary } from "@/lib/DictionaryProviderClient";
 import mergePDFHandler from "./pdf-handlers/mergePDF.js";
 import splitPDFHandler from "./pdf-handlers/splitPDF.js";
 import rotatePDFHandler from "./pdf-handlers/rotatePDF.js";
+import addPageNumbersHandler from "./pdf-handlers/addPageNumbers.js";
+import editMetaDataHandler from "./pdf-handlers/editMetaData.js";
+import LeftPageNumbers from "@/components/LeftPageNumbers.jsx";
+import LeftEditMetaData from "@/components/LeftEditMetaData.jsx";
 
 let imageURLFunction, getPDFPageCount;
 const acceptPDFFilesProps = {
@@ -52,6 +56,17 @@ const preProcessFiles = async (acceptedFiles, startKeyFrom = 0) => {
     file.getPageCount = () => getPDFPageCount(file);
     file.pageCount = null;
   });
+  return acceptedFiles;
+};
+
+const preProcessFilesWithPageCount = async (
+  acceptedFiles,
+  startKeyFrom = 0,
+) => {
+  await preProcessFiles(acceptedFiles, startKeyFrom);
+  for (const file of acceptedFiles) {
+    file.pageCount = await getPDFPageCount(file);
+  }
   return acceptedFiles;
 };
 
@@ -123,6 +138,26 @@ const pdftoolsconfig = {
         </div>
       );
     },
+  },
+  add_page_number: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFilesWithPageCount,
+    multiple: false,
+    reorder: false,
+    processor: (files) => addPageNumbersHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: null,
+    LeftExtra: ({ files }) => <LeftPageNumbers file={files[0]} />,
+  },
+  edit_metadata: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFiles,
+    multiple: false,
+    reorder: false,
+    processor: (files) => editMetaDataHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: null,
+    LeftExtra: ({ files }) => <LeftEditMetaData file={files[0]} />,
   },
 };
 


### PR DESCRIPTION
## Summary
- Add **Add Page Numbers** tool with position grid, margin, page range, first number, and font size options
- Add **Edit Metadata** tool with title, subject, author, creator, producer, keywords, and date fields
- Both tools use the revamp config-driven architecture with handlers, left sidebar components, and pdftoolsconfig entries

## Test plan
- [ ] Verify `pnpm build` passes (SSG generates `/pdf-tools/add_page_number` and `/pdf-tools/edit_metadata` routes)
- [ ] Upload a PDF to Add Page Numbers, configure position/margin/range/font size, save and verify output
- [ ] Upload a PDF to Edit Metadata, fill all fields including dates/keywords, save and verify metadata in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)