### PR TITLE
Add Break PDF tool to revamp

### DIFF
--- a/src/components/LeftBreakPDF.jsx
+++ b/src/components/LeftBreakPDF.jsx
@@ -1,0 +1,53 @@
+"use client";
+import React, { useEffect, useRef } from "react";
+
+export default function LeftBreakPDF({ file }) {
+  const maxPagesInputRef = useRef(null);
+
+  useEffect(() => {
+    file.breakPDFIncludeLastPages = true;
+    file.breakPDFMaxPages = 1;
+  }, []);
+
+  const onMaxPagesInputChange = () => {
+    let val = parseInt(maxPagesInputRef.current.value);
+    if (val < 1) {
+      val = 1;
+      maxPagesInputRef.current.value = 1;
+    }
+    if (val > file.pageCount) {
+      val = file.pageCount;
+      maxPagesInputRef.current.value = file.pageCount;
+    }
+    file.breakPDFMaxPages = val;
+  };
+
+  const onIncludeLastPageInputChange = (e) => {
+    file.breakPDFIncludeLastPages = e.target.checked;
+  };
+
+  return (
+    <>
+      <div className="flex place-items-center mt-2">
+        <span className="w-1/2">Max Pages in A File</span>
+        <input
+          ref={maxPagesInputRef}
+          className="w-1/2 py-1 text-center caret-transparent rounded-md bg-[#FFFFFF42] text-white border border-[#E9B4BF80]"
+          type="number"
+          defaultValue="1"
+          min="1"
+          max={file.pageCount}
+          onChange={onMaxPagesInputChange}
+        />
+      </div>
+      <div className="flex place-items-center mt-2">
+        <span className="w-1/2">Include Last Pages</span>
+        <input
+          type="checkbox"
+          onChange={onIncludeLastPageInputChange}
+          defaultChecked={true}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/lib/pdf-handlers/breakPDF.js
+++ b/src/lib/pdf-handlers/breakPDF.js
@@ -1,0 +1,33 @@
+import { createPDF, pdfArrayToBlob, breakPDF, zipToBlob } from "pdf-actions";
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+
+const breakPDFHandler = async (files, asZip = true) => {
+  let zip;
+  if (asZip) {
+    zip = new JSZip();
+  }
+  const file = files[0];
+  const pdfFile = await createPDF.PDFDocumentFromFile(file);
+  const docsFile = await breakPDF(
+    pdfFile,
+    file.breakPDFMaxPages,
+    file.breakPDFIncludeLastPages,
+    file.rotate,
+  );
+  for (let i = 0; i < docsFile.length; i++) {
+    const docArray = await docsFile[i].save();
+    if (asZip) {
+      zip.file(`break-${i + 1}-${file.name}`, docArray);
+    } else {
+      const pdfBlob = pdfArrayToBlob(docArray);
+      saveAs(pdfBlob, `break-${i + 1}-${file.name}`);
+    }
+  }
+  if (asZip) {
+    const zipBlob = await zipToBlob(zip);
+    saveAs(zipBlob, "breakPDFFiles.zip");
+  }
+};
+
+export default breakPDFHandler;

--- a/src/lib/pdftoolsconfig.js
+++ b/src/lib/pdftoolsconfig.js
@@ -6,10 +6,12 @@ import {
 } from "@/components/FileComponents.jsx";
 import GlassButton from "@/components/GlassButton.jsx";
 import { LeftRotate } from "@/components/LeftComponents.jsx";
+import LeftBreakPDF from "@/components/LeftBreakPDF.jsx";
 import { useDictionary } from "@/lib/DictionaryProviderClient";
 import mergePDFHandler from "./pdf-handlers/mergePDF.js";
 import splitPDFHandler from "./pdf-handlers/splitPDF.js";
 import rotatePDFHandler from "./pdf-handlers/rotatePDF.js";
+import breakPDFHandler from "./pdf-handlers/breakPDF.js";
 
 let imageURLFunction, getPDFPageCount;
 const acceptPDFFilesProps = {
@@ -53,6 +55,14 @@ const preProcessFiles = async (acceptedFiles, startKeyFrom = 0) => {
     file.pageCount = null;
   });
   return acceptedFiles;
+};
+
+const preProcessFilesWithPageCount = async (acceptedFiles, startKeyFrom = 0) => {
+  const files = await preProcessFiles(acceptedFiles, startKeyFrom);
+  for (const file of files) {
+    file.pageCount = await getPDFPageCount(file);
+  }
+  return files;
 };
 
 const pdftoolsconfig = {
@@ -119,6 +129,31 @@ const pdftoolsconfig = {
           <GlassButton onClick={() => rotatePDFHandler(files, false)}>
             {pdf_tools.main.save_as_individual}
           </GlassButton>
+          <LeftRotate files={files} />
+        </div>
+      );
+    },
+  },
+  break_pdf: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFilesWithPageCount,
+    multiple: false,
+    reorder: false,
+    processor: (files) => breakPDFHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: ({ file }) => (
+      <div className="mx-auto max-w-[80%] flex-col">
+        <FileRotate file={file} />
+      </div>
+    ),
+    LeftExtra: ({ files }) => {
+      const { pdf_tools } = useDictionary();
+      return (
+        <div className="flex flex-col gap-4">
+          <GlassButton onClick={() => breakPDFHandler(files, false)}>
+            {pdf_tools.main.save_as_individual}
+          </GlassButton>
+          <LeftBreakPDF file={files[0]} />
           <LeftRotate files={files} />
         </div>
       );


### PR DESCRIPTION
## Summary
- Migrate Break PDF tool from master branch to revamp's config-driven architecture
- New handler (`breakPDF.js`) that splits a single PDF into multiple files by max-pages-per-file
- New left sidebar component (`LeftBreakPDF.jsx`) for break settings (max pages, include last pages)
- Config entry in `pdftoolsconfig.js` with eager pageCount resolution

## Test plan
- [ ] Run `pnpm build` to verify successful build
- [ ] Navigate to `/pdf-tools/break_pdf` and verify the tool loads
- [ ] Upload a multi-page PDF and test breaking with various max-pages settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)