### PR TITLE
Add Resize PDF and Add Margin tools to revamp

### DIFF
--- a/src/components/LeftMargin.jsx
+++ b/src/components/LeftMargin.jsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React, { useEffect } from "react";
+
+const fieldClassName =
+  "bg-white/20 w-full py-2 pl-2 rounded-md text-white outline-none";
+
+const units = ["Inches", "Centimeters", "Millimeters"];
+const marginSides = [
+  {
+    text: "Left",
+    arrayIndex: 0,
+    unitId: "marginLeftUnit",
+    textInputId: "marginLeftValue",
+  },
+  {
+    text: "Top",
+    arrayIndex: 1,
+    unitId: "marginTopUnit",
+    textInputId: "marginTopValue",
+  },
+  {
+    text: "Right",
+    arrayIndex: 2,
+    unitId: "marginRightUnit",
+    textInputId: "marginRightValue",
+  },
+  {
+    text: "Bottom",
+    arrayIndex: 3,
+    unitId: "marginBottomUnit",
+    textInputId: "marginBottomValue",
+  },
+];
+
+export default function LeftMargin({ files }) {
+  useEffect(() => {
+    if (files[0]) {
+      files[0].marginMillimeter = [0, 0, 0, 0];
+    }
+  }, []);
+
+  const handleMarginValueChange = (marginIndex, unitId, textInputId) => {
+    const unit = document.getElementById(unitId).value;
+    const newValue = document.getElementById(textInputId).value;
+    const newValueFloat = newValue === "" ? 0 : parseFloat(newValue);
+    let newValueMillimeter = newValueFloat;
+    if (unit === "Inches") {
+      newValueMillimeter =
+        Math.round((25.4 * newValueFloat + Number.EPSILON) * 100) / 100;
+    } else if (unit === "Centimeters") {
+      newValueMillimeter =
+        Math.round((10 * newValueFloat + Number.EPSILON) * 100) / 100;
+    }
+    if (files[0]) {
+      if (!files[0].marginMillimeter) {
+        files[0].marginMillimeter = [0, 0, 0, 0];
+      }
+      files[0].marginMillimeter[marginIndex] = newValueMillimeter;
+    }
+  };
+
+  return (
+    <div className="w-full mt-2 py-2 tracking-wider border-y-2 border-white/30 text-white">
+      Margin Settings
+      {marginSides.map((side) => (
+        <div key={side.arrayIndex} className="flex items-center gap-2 mt-2">
+          <span className="w-16 shrink-0">{side.text}</span>
+          <input
+            id={side.textInputId}
+            type="number"
+            defaultValue={0}
+            min={0}
+            className={fieldClassName}
+            onChange={() =>
+              handleMarginValueChange(
+                side.arrayIndex,
+                side.unitId,
+                side.textInputId,
+              )
+            }
+          />
+          <select
+            id={side.unitId}
+            className={fieldClassName}
+            onChange={() =>
+              handleMarginValueChange(
+                side.arrayIndex,
+                side.unitId,
+                side.textInputId,
+              )
+            }
+          >
+            {units.map((u, i) => (
+              <option key={i} value={u} className="text-black">
+                {u}
+              </option>
+            ))}
+          </select>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/LeftResizePDF.jsx
+++ b/src/components/LeftResizePDF.jsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+
+const selectClassName =
+  "bg-white/20 w-1/2 py-2 pl-2 rounded-md text-white outline-none";
+
+const resizeSizes = ["A4", "A3", "A5", "Legal", "Letter", "Tabloid"];
+const orientations = ["Portrait", "Landscape"];
+const positions = ["Start", "Center", "End"];
+
+export default function LeftResizePDF() {
+  return (
+    <div className="w-full mt-2 py-2 tracking-wider border-y-2 border-white/30 text-white">
+      Page Settings
+      <div className="flex justify-between items-center mt-2">
+        Size
+        <select id="resizeSize" className={selectClassName}>
+          {resizeSizes.map((s, i) => (
+            <option key={i} value={s} className="text-black">
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex justify-between items-center mt-2">
+        Orientation
+        <select id="orientation" className={selectClassName}>
+          {orientations.map((o, i) => (
+            <option key={i} value={o} className="text-black">
+              {o}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex justify-between items-center mt-2">
+        Position
+        <select id="position" className={selectClassName}>
+          {positions.map((p, i) => (
+            <option key={i} value={p} className="text-black">
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/pdf-handlers/addMargin.js
+++ b/src/lib/pdf-handlers/addMargin.js
@@ -1,0 +1,36 @@
+import { createPDF, pdfArrayToBlob, addMarginPDF, zipToBlob } from "pdf-actions";
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+
+const addMarginHandler = async (files, asZip = true) => {
+  const marginMillimeter = files[0].marginMillimeter || [0, 0, 0, 0];
+  let zip;
+  if (asZip) {
+    zip = new JSZip();
+  }
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (file.deleted) {
+      continue;
+    }
+    const pdfDocument = await createPDF.PDFDocumentFromFile(file);
+    const addedMarginFile = await addMarginPDF(
+      pdfDocument,
+      marginMillimeter,
+      file.rotate,
+    );
+    const pdfFile = await addedMarginFile.save();
+    if (asZip) {
+      zip.file(`newMargin-${file.name}`, pdfFile);
+    } else {
+      const pdfBlob = pdfArrayToBlob(pdfFile);
+      saveAs(pdfBlob, `newMargin-${file.name}`);
+    }
+  }
+  if (asZip) {
+    const zipBlob = await zipToBlob(zip);
+    saveAs(zipBlob, "newMarginPDFFiles.zip");
+  }
+};
+
+export default addMarginHandler;

--- a/src/lib/pdf-handlers/resizePDF.js
+++ b/src/lib/pdf-handlers/resizePDF.js
@@ -1,0 +1,40 @@
+import { saveAs } from "file-saver";
+import JSZip from "jszip";
+import { createPDF, pdfArrayToBlob, resizePDF, zipToBlob } from "pdf-actions";
+
+const resizePDFHandler = async (files, asZip = true) => {
+  const resizeSize = document.getElementById("resizeSize").value;
+  const orientation = document.getElementById("orientation").value;
+  const position = document.getElementById("position").value;
+  let zip;
+  if (asZip) {
+    zip = new JSZip();
+  }
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (file.deleted) {
+      continue;
+    }
+    const pdfDocument = await createPDF.PDFDocumentFromFile(file);
+    const resizedPDF = await resizePDF(
+      pdfDocument,
+      resizeSize,
+      orientation,
+      position,
+      file.rotate,
+    );
+    const pdfFile = await resizedPDF.save();
+    if (asZip) {
+      zip.file(`resized-${file.name}`, pdfFile);
+    } else {
+      const pdfBlob = pdfArrayToBlob(pdfFile);
+      saveAs(pdfBlob, `resized-${file.name}`);
+    }
+  }
+  if (asZip) {
+    const zipBlob = await zipToBlob(zip);
+    saveAs(zipBlob, "resizedPDFFiles.zip");
+  }
+};
+
+export default resizePDFHandler;

--- a/src/lib/pdftoolsconfig.js
+++ b/src/lib/pdftoolsconfig.js
@@ -10,6 +10,10 @@ import { useDictionary } from "@/lib/DictionaryProviderClient";
 import mergePDFHandler from "./pdf-handlers/mergePDF.js";
 import splitPDFHandler from "./pdf-handlers/splitPDF.js";
 import rotatePDFHandler from "./pdf-handlers/rotatePDF.js";
+import resizePDFHandler from "./pdf-handlers/resizePDF.js";
+import addMarginHandler from "./pdf-handlers/addMargin.js";
+import LeftResizePDF from "@/components/LeftResizePDF.jsx";
+import LeftMargin from "@/components/LeftMargin.jsx";
 
 let imageURLFunction, getPDFPageCount;
 const acceptPDFFilesProps = {
@@ -119,6 +123,58 @@ const pdftoolsconfig = {
           <GlassButton onClick={() => rotatePDFHandler(files, false)}>
             {pdf_tools.main.save_as_individual}
           </GlassButton>
+          <LeftRotate files={files} />
+        </div>
+      );
+    },
+  },
+  resize: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFiles,
+    multiple: true,
+    reorder: false,
+    processor: (files) => resizePDFHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: ({ file }) => (
+      <div className="mx-auto max-w-[80%] flex-col">
+        <FileRotate file={file} />
+        <FileDelete file={file} />
+      </div>
+    ),
+    LeftExtra: ({ files }) => {
+      const { pdf_tools } = useDictionary();
+      return (
+        <div className="flex flex-col gap-4">
+          <GlassButton onClick={() => resizePDFHandler(files, false)}>
+            {pdf_tools.main.save_as_individual}
+          </GlassButton>
+          <LeftResizePDF />
+          <LeftRotate files={files} />
+        </div>
+      );
+    },
+  },
+  add_margin: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFiles,
+    multiple: true,
+    reorder: false,
+    processor: (files) => addMarginHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: ({ file }) => (
+      <div className="mx-auto max-w-[80%] flex-col">
+        <FileRotate file={file} />
+        <FileDelete file={file} />
+      </div>
+    ),
+    LeftExtra: ({ files }) => {
+      const { pdf_tools } = useDictionary();
+      return (
+        <div className="flex flex-col gap-4">
+          <GlassButton onClick={() => addMarginHandler(files, false)}>
+            {pdf_tools.main.save_as_individual}
+          </GlassButton>
+          <LeftMargin files={files} />
           <LeftRotate files={files} />
         </div>
       );


### PR DESCRIPTION
## Summary
- Migrate Resize PDF and Add Margin tools from master branch to revamp
- New handlers (`resizePDF.js`, `addMargin.js`) with zip/individual download support
- New left sidebar components (`LeftResizePDF.jsx`, `LeftMargin.jsx`) for page size, orientation, position, and margin settings with unit conversion
- Config entries in `pdftoolsconfig.js` for both tools

## Test plan
- [ ] Run `pnpm build` to verify successful build
- [ ] Navigate to `/pdf-tools/resize` and test resizing with various page sizes
- [ ] Navigate to `/pdf-tools/add_margin` and test adding margins with different units

🤖 Generated with [Claude Code](https://claude.com/claude-code)