### PR TITLE
Add JPG to PDF tool to revamp

### DIFF
--- a/src/components/ImagePreviewComponent.jsx
+++ b/src/components/ImagePreviewComponent.jsx
@@ -1,0 +1,60 @@
+"use client";
+import React, { useEffect, useRef } from "react";
+import Image from "next/image";
+import styles from "@/styles/CustomImageComponent.module.css";
+import { cn } from "@/lib/utils";
+
+function ImagePreviewComponent({ file }) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (file.imageDataURL) {
+      ref.current.src = file.imageDataURL;
+      ref.current.width = 150;
+      ref.current.height = 150;
+      file.imageRef = ref;
+      ref.current.style.rotate = `${file.rotate}deg`;
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    file.imageDataURL = url;
+    ref.current.src = url;
+    ref.current.width = 150;
+    ref.current.height = 150;
+    file.imageRef = ref;
+    ref.current.style.rotate = `${file.rotate}deg`;
+  }, []);
+
+  return (
+    <div className="relative mx-auto grid aspect-square w-[150px] place-items-center">
+      <Image
+        className={cn("absolute right-0 top-0 z-40", styles.info_icon)}
+        src="/icons/common/info.png"
+        width={16}
+        height={16}
+        alt="file_info"
+      />
+      <ul
+        className={cn(
+          "absolute right-0 top-0 z-50 w-[150px] rounded-md bg-primary p-2 text-xs text-white",
+          styles["info_container"],
+        )}
+      >
+        <li className="line-clamp-2">Name : {file.name}</li>
+        <li className="line-clamp-2">Size : {file.size}</li>
+        <li className="line-clamp-2">File Type : {file.type}</li>
+      </ul>
+      <Image
+        onDragStart={() => false}
+        ref={ref}
+        src="/icons/puff_loader.svg"
+        className="pointer-events-none z-30 object-contain transition-[rotate]"
+        width={100}
+        height={100}
+        alt={file.name}
+      />
+    </div>
+  );
+}
+
+export default ImagePreviewComponent;

--- a/src/components/LeftImageMargin.jsx
+++ b/src/components/LeftImageMargin.jsx
@@ -1,0 +1,97 @@
+"use client";
+import React, { useEffect } from "react";
+
+const units = ["Inches", "Centimeters", "Millimeters"];
+const marginSides = [
+  {
+    text: "Left",
+    arrayIndex: 0,
+    unitId: "imgMarginLeftUnit",
+    textInputId: "imgMarginLeftValue",
+  },
+  {
+    text: "Top",
+    arrayIndex: 1,
+    unitId: "imgMarginTopUnit",
+    textInputId: "imgMarginTopValue",
+  },
+  {
+    text: "Right",
+    arrayIndex: 2,
+    unitId: "imgMarginRightUnit",
+    textInputId: "imgMarginRightValue",
+  },
+  {
+    text: "Bottom",
+    arrayIndex: 3,
+    unitId: "imgMarginBottomUnit",
+    textInputId: "imgMarginBottomValue",
+  },
+];
+
+export default function LeftImageMargin({ files }) {
+  useEffect(() => {
+    if (files[0]) files[0].marginMillimeter = [0, 0, 0, 0];
+  }, []);
+
+  const handleMarginValueChange = (marginIndex, unitId, textInputId) => {
+    const unit = document.getElementById(unitId).value;
+    const newValue = document.getElementById(textInputId).value;
+    const newValueFloat = newValue === "" ? 0 : parseFloat(newValue);
+    let newValueMillimeter = newValueFloat;
+    if (unit === "Inches")
+      newValueMillimeter =
+        Math.round((25.4 * newValueFloat + Number.EPSILON) * 100) / 100;
+    else if (unit === "Centimeters")
+      newValueMillimeter =
+        Math.round((10 * newValueFloat + Number.EPSILON) * 100) / 100;
+    if (files[0]) {
+      if (!files[0].marginMillimeter) files[0].marginMillimeter = [0, 0, 0, 0];
+      files[0].marginMillimeter[marginIndex] = newValueMillimeter;
+    }
+  };
+
+  return (
+    <div className="w-full border-y border-white/30 py-2 tracking-wider">
+      <p className="mb-2 font-medium">Margin Settings</p>
+      {marginSides.map((marginSide, i) => (
+        <div className="mt-2 flex items-center justify-between" key={i}>
+          <span>{marginSide.text}</span>
+          <div className="flex">
+            <input
+              type="number"
+              id={marginSide.textInputId}
+              className="h-[36px] w-16 rounded-l-md bg-white/20 text-center"
+              step={0.1}
+              defaultValue={0}
+              onChange={() =>
+                handleMarginValueChange(
+                  marginSide.arrayIndex,
+                  marginSide.unitId,
+                  marginSide.textInputId,
+                )
+              }
+            />
+            <select
+              id={marginSide.unitId}
+              className="h-[36px] rounded-r-md bg-white/20 text-xs"
+              onChange={() =>
+                handleMarginValueChange(
+                  marginSide.arrayIndex,
+                  marginSide.unitId,
+                  marginSide.textInputId,
+                )
+              }
+            >
+              {units.map((unit, i) => (
+                <option key={i} value={unit}>
+                  {unit}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/LeftResizeImage.jsx
+++ b/src/components/LeftResizeImage.jsx
@@ -1,0 +1,62 @@
+"use client";
+import React from "react";
+
+const resizeSizes = [
+  "Same as Image",
+  "A4",
+  "A3",
+  "A5",
+  "Legal",
+  "Letter",
+  "Tabloid",
+];
+const orientations = ["Portrait", "Landscape"];
+const positions = ["Start", "Center", "End"];
+
+export default function LeftResizeImage() {
+
+  return (
+    <div className="w-full border-y border-white/30 py-2 tracking-wider">
+      <p className="mb-2 font-medium">Page Settings</p>
+      <div className="flex items-center justify-between">
+        <span>Size</span>
+        <select
+          id="pageSize"
+          className="w-1/2 rounded-md bg-white/20 py-2 pl-2"
+        >
+          {resizeSizes.map((s, i) => (
+            <option key={i} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        <span>Orientation</span>
+        <select
+          id="pageOrientation"
+          className="w-1/2 rounded-md bg-white/20 py-2 pl-2"
+        >
+          {orientations.map((o, i) => (
+            <option key={i} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        <span>Image Position</span>
+        <select
+          id="imagePosition"
+          className="w-1/2 rounded-md bg-white/20 py-2 pl-2"
+        >
+          {positions.map((p, i) => (
+            <option key={i} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/pdf-handlers/imagesToPDF.js
+++ b/src/lib/pdf-handlers/imagesToPDF.js
@@ -1,0 +1,38 @@
+import { imageToPDF, mergePDF, pdfArrayToBlob } from "pdf-actions";
+import { saveAs } from "file-saver";
+
+const imagesToPDFHandler = async (files, asMergedFile = false) => {
+  const pageSize = document.getElementById("pageSize").value;
+  const pageOrientation = document.getElementById("pageOrientation").value;
+  const imagePosition = document.getElementById("imagePosition").value;
+  const marginMillimeter = files[0]?.marginMillimeter || [0, 0, 0, 0];
+  const filesToMerge = [];
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (file.deleted) continue;
+    const imagePDF = await imageToPDF(
+      file.src,
+      pageSize,
+      pageOrientation,
+      imagePosition,
+      file.rotate,
+      marginMillimeter,
+    );
+    if (asMergedFile) {
+      filesToMerge.push(imagePDF);
+    } else {
+      const pdfFile = await imagePDF.save();
+      const pdfBlob = pdfArrayToBlob(pdfFile);
+      const fileName = file.name.split(".");
+      fileName.pop();
+      saveAs(pdfBlob, `${fileName.join(".")}.pdf`);
+    }
+  }
+  if (asMergedFile) {
+    const mergedPDFFile = await (await mergePDF(filesToMerge)).save();
+    const pdfBlob = pdfArrayToBlob(mergedPDFFile);
+    saveAs(pdfBlob, "images.pdf");
+  }
+};
+
+export default imagesToPDFHandler;

--- a/src/lib/pdftoolsconfig.js
+++ b/src/lib/pdftoolsconfig.js
@@ -1,4 +1,5 @@
 import CustomImageComponent from "@/components/CustomImageComponent";
+import ImagePreviewComponent from "@/components/ImagePreviewComponent.jsx";
 import {
   FileRotate,
   FileDelete,
@@ -6,10 +7,13 @@ import {
 } from "@/components/FileComponents.jsx";
 import GlassButton from "@/components/GlassButton.jsx";
 import { LeftRotate } from "@/components/LeftComponents.jsx";
+import LeftResizeImage from "@/components/LeftResizeImage.jsx";
+import LeftImageMargin from "@/components/LeftImageMargin.jsx";
 import { useDictionary } from "@/lib/DictionaryProviderClient";
 import mergePDFHandler from "./pdf-handlers/mergePDF.js";
 import splitPDFHandler from "./pdf-handlers/splitPDF.js";
 import rotatePDFHandler from "./pdf-handlers/rotatePDF.js";
+import imagesToPDFHandler from "./pdf-handlers/imagesToPDF.js";
 
 let imageURLFunction, getPDFPageCount;
 const acceptPDFFilesProps = {
@@ -20,6 +24,11 @@ const acceptPDFFilesProps = {
 const acceptJPEGFilesProps = {
   accept: {
     "image/jpeg": [],
+  },
+};
+const acceptImageFilesProps = {
+  accept: {
+    "image/*": [],
   },
 };
 const acceptHTMLFilesProps = {
@@ -52,6 +61,21 @@ const preProcessFiles = async (acceptedFiles, startKeyFrom = 0) => {
     file.getPageCount = () => getPDFPageCount(file);
     file.pageCount = null;
   });
+  return acceptedFiles;
+};
+
+const preProcessImages = async (acceptedFiles, startKeyFrom = 0) => {
+  for (let i = 0; i < acceptedFiles.length; i++) {
+    const file = acceptedFiles[i];
+    const imageURL = URL.createObjectURL(file);
+    const imageBytes = await fetch(imageURL).then((res) => res.arrayBuffer());
+    file.src = imageBytes;
+    file.imageDataURL = imageURL;
+    file.key = i + startKeyFrom;
+    file.rotate = 0;
+    file.imageRef = null;
+    file.deleted = false;
+  }
   return acceptedFiles;
 };
 
@@ -123,6 +147,30 @@ const pdftoolsconfig = {
         </div>
       );
     },
+  },
+  jpg_to_pdf: {
+    dropZoneProps: acceptImageFilesProps,
+    preProcessFiles: preProcessImages,
+    multiple: true,
+    reorder: true,
+    processor: (files) => imagesToPDFHandler(files),
+    Preview: ({ file }) => <ImagePreviewComponent file={file} />,
+    FileExtra: ({ file }) => (
+      <div className="mx-auto max-w-[80%] flex-col">
+        <FileRotate file={file} />
+        <FileDelete file={file} />
+      </div>
+    ),
+    LeftExtra: ({ files }) => (
+      <div className="flex flex-col gap-4">
+        <GlassButton onClick={() => imagesToPDFHandler(files, true)}>
+          Save as Merged File
+        </GlassButton>
+        <LeftResizeImage />
+        <LeftImageMargin files={files} />
+        <LeftRotate files={files} />
+      </div>
+    ),
   },
 };
 


### PR DESCRIPTION
## Summary
- Migrate image-to-PDF conversion from master branch to revamp
- New handler (`imagesToPDF.js`) supporting individual and merged PDF output
- New `ImagePreviewComponent.jsx` for displaying image thumbnails (distinct from PDF preview)
- New left sidebar components (`LeftResizeImage.jsx`, `LeftImageMargin.jsx`) for page size, orientation, and margin settings
- Custom `preProcessImages` function and `acceptImageFilesProps` for image file handling
- Config entry in `pdftoolsconfig.js` with sortable image grid

## Test plan
- [ ] Run `pnpm build` to verify successful build
- [ ] Navigate to `/pdf-tools/jpg_to_pdf` and upload images
- [ ] Test individual PDF download and merged PDF download
- [ ] Test reordering images via drag-and-drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)