### PR TITLE
Add Compress PDF and Extract Images tools

### DIFF
--- a/src/lib/pdf-handlers/compress.js
+++ b/src/lib/pdf-handlers/compress.js
@@ -1,0 +1,41 @@
+import { createPDF, pdfArrayToBlob, zipToBlob } from "pdf-actions";
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+
+const compressHandler = async (files, asZip = true) => {
+  let zip;
+  if (asZip) {
+    zip = new JSZip();
+  }
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (file.deleted) {
+      continue;
+    }
+    const pdfDoc = await createPDF.PDFDocumentFromFile(file);
+
+    // Strip metadata to reduce size
+    pdfDoc.setTitle("");
+    pdfDoc.setAuthor("");
+    pdfDoc.setSubject("");
+    pdfDoc.setCreator("");
+    pdfDoc.setProducer("");
+    pdfDoc.setKeywords([]);
+
+    // Save with object streams for better compression
+    const compressedBytes = await pdfDoc.save({ useObjectStreams: true });
+
+    if (asZip) {
+      zip.file(`compressed-${file.name}`, compressedBytes);
+    } else {
+      const pdfBlob = pdfArrayToBlob(compressedBytes);
+      saveAs(pdfBlob, `compressed-${file.name}`);
+    }
+  }
+  if (asZip) {
+    const zipBlob = await zipToBlob(zip);
+    saveAs(zipBlob, "compressedPDFs.zip");
+  }
+};
+
+export default compressHandler;

--- a/src/lib/pdf-handlers/extractImages.js
+++ b/src/lib/pdf-handlers/extractImages.js
@@ -1,0 +1,34 @@
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+
+const extractImagesHandler = async (files) => {
+  const { getDocument } = await import("pdfjs-dist");
+
+  const file = files[0];
+  const fileURL = URL.createObjectURL(file);
+  const doc = await getDocument({ url: fileURL }).promise;
+  const zip = new JSZip();
+  const scale = 2;
+
+  for (let i = 1; i <= doc.numPages; i++) {
+    const page = await doc.getPage(i);
+    const vp = page.getViewport({ scale });
+    const canvas = document.createElement("canvas");
+    canvas.width = vp.width;
+    canvas.height = vp.height;
+    const ctx = canvas.getContext("2d");
+    await page.render({ canvasContext: ctx, viewport: vp }).promise;
+
+    const blob = await new Promise((resolve) =>
+      canvas.toBlob(resolve, "image/png"),
+    );
+    const arrayBuffer = await blob.arrayBuffer();
+    zip.file(`page-${i}.png`, arrayBuffer);
+  }
+
+  URL.revokeObjectURL(fileURL);
+  const zipBlob = await zip.generateAsync({ type: "blob" });
+  saveAs(zipBlob, `${file.name}-images.zip`);
+};
+
+export default extractImagesHandler;

--- a/src/lib/pdftoolsconfig.js
+++ b/src/lib/pdftoolsconfig.js
@@ -26,6 +26,8 @@ import addPageNumbersHandler from "./pdf-handlers/addPageNumbers.js";
 import editMetaDataHandler from "./pdf-handlers/editMetaData.js";
 import resizePDFHandler from "./pdf-handlers/resizePDF.js";
 import addMarginHandler from "./pdf-handlers/addMargin.js";
+import compressHandler from "./pdf-handlers/compress.js";
+import extractImagesHandler from "./pdf-handlers/extractImages.js";
 
 let imageURLFunction, getPDFPageCount;
 const acceptPDFFilesProps = {
@@ -320,6 +322,37 @@ const pdftoolsconfig = {
     multiple: false,
     reorder: false,
     processor: (files) => removeMetaDataHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: null,
+    LeftExtra: null,
+  },
+  compress: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFiles,
+    multiple: true,
+    reorder: false,
+    processor: (files) => compressHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: ({ file }) => (
+      <div className="mx-auto max-w-[80%] flex-col">
+        <FileDelete file={file} />
+      </div>
+    ),
+    LeftExtra: ({ files }) => {
+      const { pdf_tools } = useDictionary();
+      return (
+        <GlassButton onClick={() => compressHandler(files, false)}>
+          {pdf_tools.main.save_as_individual}
+        </GlassButton>
+      );
+    },
+  },
+  extract_images: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFiles,
+    multiple: false,
+    reorder: false,
+    processor: (files) => extractImagesHandler(files),
     Preview: ({ file }) => <CustomImageComponent file={file} />,
     FileExtra: null,
     LeftExtra: null,


### PR DESCRIPTION
## Summary
- Add **Compress PDF** tool: strips metadata and saves with object streams for reduced file size. Supports multiple files with zip or individual download.
- Add **Extract Images** tool: renders each PDF page as a high-quality PNG and packages them in a zip file. Single-file mode only.

## Test plan
- [ ] Upload a PDF to `/pdf-tools/compress`, verify compressed output is smaller and downloadable
- [ ] Upload multiple PDFs, verify zip output and "Save as Individual" button work
- [ ] Upload a PDF to `/pdf-tools/extract_images`, verify PNG images are generated per page in a zip
- [ ] Verify both tools appear in the navigation and render correctly in both en and hi-IN locales