### PR TITLE
Implement watermark PDF tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "negotiator": "^0.6.3",
     "next": "14.0.4",
     "pdf-actions": "^1.2.2",
+    "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^4.0.379",
     "react": "^18",
     "react-dom": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 2.0.5
       framer-motion:
         specifier: ^10.17.9
-        version: 10.18.0(react-dom@18.2.0)(react@18.2.0)
+        version: 10.18.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -31,10 +31,13 @@ importers:
         version: 0.6.3
       next:
         specifier: 14.0.4
-        version: 14.0.4(react-dom@18.2.0)(react@18.2.0)
+        version: 14.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       pdf-actions:
         specifier: ^1.2.2
         version: 1.2.2
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       pdfjs-dist:
         specifier: ^4.0.379
         version: 4.0.379
@@ -49,7 +52,7 @@ importers:
         version: 14.2.3(react@18.2.0)
       react-easy-sort:
         specifier: ^1.6.0
-        version: 1.6.0(react-dom@18.2.0)(react@18.2.0)
+        version: 1.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       sharp:
         specifier: ^0.33.1
         version: 0.33.1
@@ -1602,13 +1605,13 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@10.18.0(react-dom@18.2.0)(react@18.2.0):
+  framer-motion@10.18.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   fs-minipass@2.1.0:
     dependencies:
@@ -1811,7 +1814,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next@14.0.4(react-dom@18.2.0)(react@18.2.0):
+  next@14.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.0.4
       '@swc/helpers': 0.5.2
@@ -1929,8 +1932,9 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.32):
     dependencies:
       lilconfig: 3.0.0
-      postcss: 8.4.32
       yaml: 2.3.4
+    optionalDependencies:
+      postcss: 8.4.32
 
   postcss-nested@6.0.1(postcss@8.4.32):
     dependencies:
@@ -1985,7 +1989,7 @@ snapshots:
       prop-types: 15.8.1
       react: 18.2.0
 
-  react-easy-sort@1.6.0(react-dom@18.2.0)(react@18.2.0):
+  react-easy-sort@1.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       array-move: 3.0.1
       react: 18.2.0

--- a/src/components/LeftWatermark.jsx
+++ b/src/components/LeftWatermark.jsx
@@ -1,0 +1,58 @@
+"use client";
+import React from "react";
+
+const inputClassName =
+  "bg-white/20 w-20 py-1 text-center rounded-md text-white outline-none";
+
+export default function LeftWatermark() {
+  return (
+    <div className="w-full mt-2 py-2 tracking-wider border-y-2 border-white/30 text-white">
+      Watermark Settings
+      <div className="flex flex-col gap-2 mt-2">
+        <div className="flex justify-between items-center">
+          <span>Text</span>
+          <input
+            id="watermarkText"
+            type="text"
+            defaultValue="WATERMARK"
+            className="bg-white/20 w-1/2 py-1 pl-2 rounded-md text-white outline-none text-sm"
+          />
+        </div>
+        <div className="flex justify-between items-center">
+          <span>Font Size</span>
+          <input
+            id="watermarkFontSize"
+            type="number"
+            defaultValue="40"
+            min="8"
+            max="200"
+            className={inputClassName}
+          />
+        </div>
+        <div className="flex justify-between items-center">
+          <span>Opacity</span>
+          <input
+            id="watermarkOpacity"
+            type="range"
+            defaultValue="0.3"
+            min="0.05"
+            max="1"
+            step="0.05"
+            className="w-1/2"
+          />
+        </div>
+        <div className="flex justify-between items-center">
+          <span>Rotation</span>
+          <input
+            id="watermarkRotation"
+            type="number"
+            defaultValue="-45"
+            min="-180"
+            max="180"
+            className={inputClassName}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/pdf-handlers/watermark.js
+++ b/src/lib/pdf-handlers/watermark.js
@@ -1,0 +1,70 @@
+import { PDFDocument, StandardFonts, rgb, degrees } from "pdf-lib";
+import { pdfArrayToBlob, zipToBlob } from "pdf-actions";
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+
+const watermarkHandler = async (files, asZip = true) => {
+  const text =
+    document.getElementById("watermarkText").value || "WATERMARK";
+  const fontSize =
+    parseInt(document.getElementById("watermarkFontSize").value) || 40;
+  const opacity =
+    parseFloat(document.getElementById("watermarkOpacity").value) || 0.3;
+  const rotation =
+    parseInt(document.getElementById("watermarkRotation").value) || -45;
+
+  let zip;
+  if (asZip) {
+    zip = new JSZip();
+  }
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (file.deleted) {
+      continue;
+    }
+
+    const bytes = await file.arrayBuffer();
+    const pdfDoc = await PDFDocument.load(bytes, { ignoreEncryption: true });
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const pages = pdfDoc.getPages();
+
+    const textWidth = font.widthOfTextAtSize(text, fontSize);
+    const textHeight = font.heightAtSize(fontSize);
+
+    for (const page of pages) {
+      const { width, height } = page.getSize();
+      page.drawText(text, {
+        x: width / 2 - textWidth / 2,
+        y: height / 2 - textHeight / 2,
+        size: fontSize,
+        font,
+        color: rgb(0.5, 0.5, 0.5),
+        opacity,
+        rotate: degrees(rotation),
+      });
+    }
+
+    if (file.rotate) {
+      for (const page of pages) {
+        const currentRotation = page.getRotation().angle;
+        page.setRotation(degrees(currentRotation + file.rotate));
+      }
+    }
+
+    const pdfBytes = await pdfDoc.save();
+    if (asZip) {
+      zip.file(`watermark-${file.name}`, pdfBytes);
+    } else {
+      const pdfBlob = pdfArrayToBlob(pdfBytes);
+      saveAs(pdfBlob, `watermark-${file.name}`);
+    }
+  }
+
+  if (asZip) {
+    const zipBlob = await zipToBlob(zip);
+    saveAs(zipBlob, "watermarkedPDFs.zip");
+  }
+};
+
+export default watermarkHandler;

--- a/src/lib/pdftoolsconfig.js
+++ b/src/lib/pdftoolsconfig.js
@@ -14,6 +14,7 @@ import LeftPageNumbers from "@/components/LeftPageNumbers.jsx";
 import LeftEditMetaData from "@/components/LeftEditMetaData.jsx";
 import LeftResizePDF from "@/components/LeftResizePDF.jsx";
 import LeftMargin from "@/components/LeftMargin.jsx";
+import LeftWatermark from "@/components/LeftWatermark.jsx";
 import { useDictionary } from "@/lib/DictionaryProviderClient";
 import mergePDFHandler from "./pdf-handlers/mergePDF.js";
 import splitPDFHandler from "./pdf-handlers/splitPDF.js";
@@ -26,6 +27,7 @@ import addPageNumbersHandler from "./pdf-handlers/addPageNumbers.js";
 import editMetaDataHandler from "./pdf-handlers/editMetaData.js";
 import resizePDFHandler from "./pdf-handlers/resizePDF.js";
 import addMarginHandler from "./pdf-handlers/addMargin.js";
+import watermarkHandler from "./pdf-handlers/watermark.js";
 
 let imageURLFunction, getPDFPageCount;
 const acceptPDFFilesProps = {
@@ -323,6 +325,32 @@ const pdftoolsconfig = {
     Preview: ({ file }) => <CustomImageComponent file={file} />,
     FileExtra: null,
     LeftExtra: null,
+  },
+  watermark: {
+    dropZoneProps: acceptPDFFilesProps,
+    preProcessFiles: preProcessFiles,
+    multiple: true,
+    reorder: false,
+    processor: (files) => watermarkHandler(files),
+    Preview: ({ file }) => <CustomImageComponent file={file} />,
+    FileExtra: ({ file }) => (
+      <div className="mx-auto max-w-[80%] flex-col">
+        <FileRotate file={file} />
+        <FileDelete file={file} />
+      </div>
+    ),
+    LeftExtra: ({ files }) => {
+      const { pdf_tools } = useDictionary();
+      return (
+        <div className="flex flex-col gap-4">
+          <GlassButton onClick={() => watermarkHandler(files, false)}>
+            {pdf_tools.main.save_as_individual}
+          </GlassButton>
+          <LeftWatermark />
+          <LeftRotate files={files} />
+        </div>
+      );
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- Add watermark PDF tool with configurable text, font size, opacity, and rotation settings
- Create LeftWatermark component for watermark settings UI in the left panel
- Create watermark handler using pdf-lib for direct text drawing on PDF pages
- Add pdf-lib as a direct dependency and register the watermark tool in pdftoolsconfig

## Test plan
- [ ] Upload a PDF and verify the watermark tool page renders at `/en/pdf-tools/watermark`
- [ ] Adjust watermark text, font size, opacity, and rotation settings
- [ ] Save and download watermarked PDF, verify text overlay appears centered on each page
- [ ] Test "Save as Individual Files" button for multi-file download
- [ ] Verify file rotation controls still work alongside watermarking
- [ ] Test delete functionality to exclude files from processing